### PR TITLE
Version bump and node_modules structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>jshint</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.1-SNAPSHOT</version>
     <name>JSHint</name>
     <description>WebJar for JSHint</description>
     <url>http://webjars.org</url>
@@ -37,14 +37,32 @@
             <name>James Ward</name>
             <email>james@jamesward.org</email>
         </developer>
+        <developer>
+            <id>huntchr</id>
+            <name>Christopher Hunt</name>
+        </developer>
     </developers>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstreamVersion>2.3.0</upstreamVersion>
-        <upstream.url>https://raw.github.com/jshint/jshint/${upstreamVersion}/dist</upstream.url>
+        <upstreamVersion>2.4.1</upstreamVersion>
+        <upstream.url>https://github.com/jshint/jshint</upstream.url>
+        <extractDir>${project.build.directory}/jshint-${upstreamVersion}</extractDir>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>underscorejs</artifactId>
+            <version>1.5.2-1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>console-browserify</artifactId>
+            <version>0.1.6</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
@@ -54,33 +72,61 @@
                 <version>1.0-beta-4</version>
                 <executions>
                     <execution>
-                        <id>download-jshint-js</id>
+                        <id>download-archive</id>
                         <phase>process-resources</phase>
                         <goals>
                             <goal>download-single</goal>
                         </goals>
                         <configuration>
-                            <url>${upstream.url}</url>
-                            <fromFile>jshint.js</fromFile>
-                            <toDir>${destDir}</toDir>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>download-jshint-rhino-js</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                            <url>${upstream.url}</url>
-                            <fromFile>jshint-rhino.js</fromFile>
-                            <toDir>${destDir}</toDir>
+                            <url>${upstream.url}/archive</url>
+                            <fromFile>${upstreamVersion}.zip</fromFile>
+                            <toDir>${project.build.directory}</toDir>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
 
-            <plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <echo message="unzip archive"/>
+                                <unzip src="${project.build.directory}/${upstreamVersion}.zip"
+                                       dest="${project.build.directory}"/>
+
+                                <echo message="moving resources"/>
+                                <move todir="${destDir}/node_modules/jshint">
+                                    <fileset dir="${extractDir}">
+                                        <!-- include only the files specifically required to embed jshint -->
+                                        <include name="package.json"/>
+                                        <include name="data/"/>
+                                        <include name="src/jshint.js"/>
+                                        <include name="src/lex.js"/>
+                                        <include name="src/messages.js"/>
+                                        <include name="src/reg.js"/>
+                                        <include name="src/state.js"/>
+                                        <include name="src/style.js"/>
+                                        <include name="src/vars.js"/>
+                                    </fileset>
+                                </move>
+                                <move file="${extractDir}/dist/jshint.js"
+                                      toDir="${destDir}"/>
+                                <move file="${extractDir}/dist/jshint-rhino.js"
+                                      toDir="${destDir}"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+          </plugin>
+
+          <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.3.2</version>


### PR DESCRIPTION
Version bump - plus the inclusion of the jshint node-modules structure so that we can leverage the sbt-web support for modules (module paths are established by convention using the node-modules folder).
