### PR TITLE
Problem locating latest version of jshint webjar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target
-/.idea
-/*.iml
+target
+.idea
+*.iml

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.webjars</groupId>
+        <artifactId>jshint-parent</artifactId>
+        <version>2.4.1-1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <packaging>jar</packaging>
+    <groupId>org.webjars</groupId>
+    <artifactId>jshint-node</artifactId>
+    <version>2.4.1-1-SNAPSHOT</version>
+    <name>JSHint Node</name>
+    <description>WebJar for JSHint Node sources</description>
+    <url>http://webjars.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>underscorejs</artifactId>
+            <version>1.5.2-2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>console-browserify</artifactId>
+            <version>0.1.6-1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>wagon-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+              <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <id>move</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <echo message="moving resources" />
+                                <move todir="${destDir}">
+                                    <fileset dir="${extractDir}">
+                                        <!-- include only the files specifically required to embed jshint -->
+                                        <include name="package.json" />
+                                        <include name="data/" />
+                                        <include name="src/jshint.js" />
+                                        <include name="src/lex.js" />
+                                        <include name="src/messages.js" />
+                                        <include name="src/reg.js" />
+                                        <include name="src/state.js" />
+                                        <include name="src/style.js" />
+                                        <include name="src/vars.js" />
+                                    </fileset>
+                                </move>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+          </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
         <version>7</version>
     </parent>
 
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
     <groupId>org.webjars</groupId>
-    <artifactId>jshint</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
-    <name>JSHint</name>
-    <description>WebJar for JSHint</description>
+    <artifactId>jshint-parent</artifactId>
+    <version>2.4.1-1-SNAPSHOT</version>
+    <name>JSHint Parent</name>
+    <description>Parent WebJar for JSHint</description>
     <url>http://webjars.org</url>
 
     <licenses>
@@ -51,84 +51,61 @@
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>underscorejs</artifactId>
-            <version>1.5.2-1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>console-browserify</artifactId>
-            <version>0.1.6</version>
-        </dependency>
-    </dependencies>
+    <modules>
+        <module>node</module>
+        <module>web</module>
+    </modules>  
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>wagon-maven-plugin</artifactId>
-                <version>1.0-beta-4</version>
-                <executions>
-                    <execution>
-                        <id>download-archive</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                            <url>${upstream.url}/archive</url>
-                            <fromFile>${upstreamVersion}.zip</fromFile>
-                            <toDir>${project.build.directory}</toDir>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>wagon-maven-plugin</artifactId>
+                    <version>1.0-beta-4</version>
+                    <executions>
+                        <execution>
+                            <id>download-archive</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>download-single</goal>
+                            </goals>
+                            <configuration>
+                                <url>${upstream.url}/archive</url>
+                                <fromFile>${upstreamVersion}.zip</fromFile>
+                                <toDir>${project.build.directory}</toDir>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
 
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
-                <executions>
-                    <execution>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <echo message="unzip archive" />
-                                <unzip src="${project.build.directory}/${upstreamVersion}.zip" dest="${project.build.directory}" />
+              <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.7</version>
+                    <executions>
+                        <execution>
+                            <phase>process-resources</phase>
+                            <id>extract</id>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <target>
+                                    <echo message="unzip archive" />
+                                    <unzip src="${project.build.directory}/${upstreamVersion}.zip" dest="${project.build.directory}" />
+                                </target>
+                            </configuration>
+                        </execution>
+                    </executions>
+              </plugin>
 
-                                <echo message="moving resources" />
-                                <move todir="${destDir}/node_modules/jshint">
-                                    <fileset dir="${extractDir}">
-                                        <!-- include only the files specifically required to embed jshint -->
-                                        <include name="package.json" />
-                                        <include name="data/" />
-                                        <include name="src/jshint.js" />
-                                        <include name="src/lex.js" />
-                                        <include name="src/messages.js" />
-                                        <include name="src/reg.js" />
-                                        <include name="src/state.js" />
-                                        <include name="src/style.js" />
-                                        <include name="src/vars.js" />
-                                    </fileset>
-                                </move>
-                                <move file="${extractDir}/dist/jshint.js" toDir="${destDir}" />
-                                <move file="${extractDir}/dist/jshint-rhino.js" toDir="${destDir}" />
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-          </plugin>
-
-          <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.3.2</version>
-            </plugin>
-        </plugins>
+              <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-release-plugin</artifactId>
+                  <version>2.3.2</version>
+              </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.webjars</groupId>
+        <artifactId>jshint-parent</artifactId>
+        <version>2.4.1-1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <packaging>jar</packaging>
+    <artifactId>jshint</artifactId>
+    <name>JSHint</name>
+    <description>WebJar for JSHint</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>wagon-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <id>move</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <echo message="moving resources" />
+                                <move file="${extractDir}/dist/jshint.js" toDir="${destDir}" />
+                                <move file="${extractDir}/dist/jshint-rhino.js" toDir="${destDir}" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+          </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
When using jshint webjar with version 2.4.1, accessing the following webjar uri: "jshint.js" fails with message: "Multiple matches found...". 

Apparently the same webjar contains the node_modules folder which contains another file with the same name: jshint.js. As result, the webjar-locator cannot resolve the ambiguity.

Searching for a more specific webjar uri: "2.4.1/jshint.js" works, but it defends the purpose of the easily replaceable dependency, since I cannot upgrade to a newer (or older) version anymore, since the version itself is encoded in the path.

I'm not sure whether the problem should be solved by removing (probably unnecessary) node-modules folder from the jshint webjar, or making webjar-locator configurable when dealing with multiple matches or if the version should not be encoded in the path of the webjar (I know we have discussed this earlier and there is a long thread regarding this subject). 

I would like to hear your thoughts regarding this problem in this thread. 

Thanks,
Alex
